### PR TITLE
fixed broken quotes in .tag path

### DIFF
--- a/install32_64/run_me.bat
+++ b/install32_64/run_me.bat
@@ -1,8 +1,8 @@
 @echo off
 
-set TARGET_APP=%1%
+set TARGET_APP=%~1
 echo PIN is trying to run the app:
-echo %TARGET_APP%
+echo "%TARGET_APP%"
 
 rem PIN_DIR is your root directory of Intel Pin
 set PIN_DIR=C:\pin\
@@ -17,11 +17,11 @@ set PINTOOL=%PINTOOL32%
 rem TRACED_MODULE - by default it is the main module, but it can be also a DLL within the traced process
 set TRACED_MODULE=%TARGET_APP%
 
-set TAG_FILE=%TRACED_MODULE%.tag
+set TAG_FILE="%TRACED_MODULE%.tag"
 set ENABLE_SHORT_LOGGING=1
 set FOLLOW_SHELLCODES=1
 
-%PIN_TOOLS_DIR%\pe_check.exe %TARGET_APP%
+%PIN_TOOLS_DIR%\pe_check.exe "%TARGET_APP%"
 if %errorlevel% == 32 (
 	echo 32bit selected
 	set PINTOOL=%PINTOOL32%
@@ -31,10 +31,10 @@ if %errorlevel% == 64 (
 	set PINTOOL=%PINTOOL64%
 )
 
-echo Target module: %TRACED_MODULE%
+echo Target module: "%TRACED_MODULE%"
 echo Tag file: %TAG_FILE%
 
-%PIN_DIR%\pin.exe -t %PINTOOL% -m %TRACED_MODULE% -o %TAG_FILE% -f %FOLLOW_SHELLCODES% -s %ENABLE_SHORT_LOGGING% -- %TARGET_APP% 
+%PIN_DIR%\pin.exe -t %PINTOOL% -m "%TRACED_MODULE%" -o %TAG_FILE% -f %FOLLOW_SHELLCODES% -s %ENABLE_SHORT_LOGGING% -- "%TARGET_APP%" 
 
 if %ERRORLEVEL% EQU 0 echo [OK] PIN tracing finished: the traced application terminated.
 rem Pausing script after the application is executed is useful to see all eventual printed messages and for troubleshooting


### PR DESCRIPTION
I took the liberty of fixing the broken path to the .tag file in the batch script. Previously it'd look something like this:

"path\to\file".tag