### PR TITLE
Implement logging of inline syscall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 A Pin Tool for tracing:
 + API calls, including [parameters of selected functions](https://github.com/hasherezade/tiny_tracer/wiki/Tracing-parameters-of-functions)
 + selected instructions: [RDTSC](https://c9x.me/x86/html/file_module_x86_id_278.html), [CPUID](https://c9x.me/x86/html/file_module_x86_id_45.html)
++ inline system calls
 + transition between sections of the traced module (helpful in finding OEP of the packed module)
 
 Bypasses the anti-tracing check based on RDTSC.

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -9,6 +9,7 @@
 
 #define KEY_FOLLOW_SHELLCODES           "FOLLOW_SHELLCODES"
 #define KEY_LOG_RTDSC                   "TRACE_RDTSC"
+#define KEY_LOG_SYSCALL                 "TRACE_SYSCALL"
 #define KEY_LOG_SECTIONS_TRANSITIONS    "LOG_SECTIONS_TRANSITIONS"
 #define KEY_LOG_SHELLCODES_TRANSITIONS  "LOG_SHELLCODES_TRANSITIONS"
 #define KEY_SHORT_LOGGING               "ENABLE_SHORT_LOGGING"
@@ -62,6 +63,10 @@ bool fillSettings(Settings &s, std::string line)
     }
     if (util::iequals(valName, KEY_LOG_RTDSC)) {
         s.traceRDTSC = loadBoolean(valStr, s.traceRDTSC);
+        isFilled = true;
+    }
+    if (util::iequals(valName, KEY_LOG_SYSCALL)) {
+        s.traceSYSCALL = loadBoolean(valStr, s.traceSYSCALL);
         isFilled = true;
     }
     if (util::iequals(valName, KEY_LOG_SECTIONS_TRANSITIONS)) {

--- a/Settings.h
+++ b/Settings.h
@@ -18,6 +18,7 @@ public:
     Settings() 
         : followShellcode(SHELLC_FOLLOW_FIRST),
         traceRDTSC(false),
+        traceSYSCALL(false),
         logSectTrans(true),
         logShelcTrans(true),
         logIndirect(false),
@@ -32,6 +33,7 @@ public:
     t_shellc_options followShellcode;
 
     bool traceRDTSC; // Trace RDTSC
+    bool traceSYSCALL; // Trace syscall instructions (i.e., syscall, int 2Eh, sysenter)
     bool logSectTrans; // watch transitions between sections
     bool logShelcTrans; // watch transitions between shellcodes
     bool shortLogging; // Use short call logging (without a full DLL path)

--- a/TraceLog.cpp
+++ b/TraceLog.cpp
@@ -109,7 +109,6 @@ void TraceLog::logRdtsc(const ADDRINT base, const ADDRINT rva)
     m_traceFile.flush();
 }
 
-
 void TraceLog::logCpuid(const ADDRINT base, const ADDRINT rva, const ADDRINT param)
 {
     if (!createFile()) return;
@@ -120,6 +119,21 @@ void TraceLog::logCpuid(const ADDRINT base, const ADDRINT rva, const ADDRINT par
         << std::hex << rva
         << DELIMITER
         << "CPUID:"
+        << std::hex << param
+        << std::endl;
+    m_traceFile.flush();
+}
+
+void TraceLog::logSyscall(const ADDRINT base, const ADDRINT rva, const ADDRINT param)
+{
+    if (!createFile()) return;
+    if (base) {
+        m_traceFile << "> " << std::hex << base << "+";
+    }
+    m_traceFile
+        << std::hex << rva
+        << DELIMITER
+        << "SYSCALL:"
         << std::hex << param
         << std::endl;
     m_traceFile.flush();

--- a/TraceLog.h
+++ b/TraceLog.h
@@ -34,6 +34,7 @@ public:
     void logIndirectCall(const ADDRINT prevModuleBase, const ADDRINT prevAddr, bool isRVA, const ADDRINT calledBase, const ADDRINT callRVA);
     void logRdtsc(const ADDRINT base, const ADDRINT rva);
     void logCpuid(const ADDRINT base, const ADDRINT rva, const ADDRINT param);
+    void logSyscall(const ADDRINT base, const ADDRINT rva, const ADDRINT param);
 
     void logLine(std::string str);
 

--- a/install32_64/TinyTracer.ini
+++ b/install32_64/TinyTracer.ini
@@ -6,6 +6,7 @@ FOLLOW_SHELLCODES=1
 ; 2 : follow also the shellcodes called recursively from the the original shellcode
 ; 3 : follow any shellcodes
 TRACE_RDTSC=False
+TRACE_SYSCALL=True
 LOG_SECTIONS_TRANSITIONS=True
 LOG_SHELLCODES_TRANSITIONS=True
 HEXDUMP_SIZE=8


### PR DESCRIPTION
Hi,

Here's a small PR that adds an option to trace inline system calls instructions (`syscall`, `sysenter` and `int 2Eh`). This feature can be useful when analyzing some samples.
The implementation is very similar to what existed for the `cpuid` instruction tracing.

I tested the feature on Windows 10 x64 with 32-bit and 64-bit PEs.
A small trick is used to have meaningful addresses when tracing WoW64 processes (because inspecting the 64-bit context isn't practical).

Only the syscall number is traced at the moment, but parameters tracing shouldn't be too complex to implement later with `PIN_GetSyscallArgument` if needed/wanted.

Feel free to close the PR if you don't want to merge that feature into your project.

Best regards.
