### PR TITLE
Implement syscall parameters tracing

### DIFF
--- a/FuncWatch.cpp
+++ b/FuncWatch.cpp
@@ -31,6 +31,37 @@ bool WFuncInfo::update(const WFuncInfo &func_info)
 
 //---
 
+bool WSyscallInfo::load(const std::string& sline, char delimiter)
+{
+    std::vector<std::string> args;
+    util::splitList(sline, delimiter, args);
+    if (args.size() < 3) return false;
+    // Note: '<' and '>' are used to ensure this cannot overlap with a valid
+    // file or library name.
+    if (args[0] != "<SYSCALL>") return false;
+
+    // Parse syscall ID as a hexadecimal number
+    const int syscallId = util::loadInt(args[1], true);
+    if (syscallId < 0) return false;
+
+    this->syscallId = static_cast<uint32_t>(syscallId);
+    this->paramCount = util::loadInt(args[2]);
+
+    return true;
+}
+
+bool WSyscallInfo::update(const WSyscallInfo& syscall_info)
+{
+    bool isUpdated = false;
+    if (this->paramCount < syscall_info.paramCount) {
+        this->paramCount = syscall_info.paramCount;
+        isUpdated = true;
+    }
+    return isUpdated;
+}
+
+//---
+
 WFuncInfo* FuncWatchList::findFunc(const std::string& dllName, const std::string &funcName)
 {
     for (size_t i = 0; i < funcs.size(); i++)
@@ -60,6 +91,17 @@ bool FuncWatchList::appendFunc(WFuncInfo &func_info)
     return true;
 }
 
+void FuncWatchList::appendSyscall(WSyscallInfo& syscall_info)
+{
+    auto& it = syscalls.find(syscall_info.syscallId);
+    if (it == syscalls.end()) {
+        syscalls[syscall_info.syscallId] = syscall_info;
+    }
+    else {
+        it->second.update(syscall_info);
+    }
+}
+
 size_t FuncWatchList::loadList(const char* filename)
 {
     std::ifstream myfile(filename);
@@ -72,6 +114,14 @@ size_t FuncWatchList::loadList(const char* filename)
     while (!myfile.eof()) {
         myfile.getline(line, MAX_LINE);
 
+        // Try to parse as a syscall
+        WSyscallInfo syscall_info;
+        if (syscall_info.load(line, ';')) {
+            appendSyscall(syscall_info);
+            continue;
+        }
+
+        // Try to parse as a function
         WFuncInfo func_info;
         if (func_info.load(line, ';')) {
             appendFunc(func_info);

--- a/FuncWatch.h
+++ b/FuncWatch.h
@@ -5,11 +5,11 @@
 #include <iostream>
 #include <cstring>
 #include <cstdio>
+#include <map>
 #include <vector>
 
-class WFuncInfo 
+struct WFuncInfo 
 {
-public:
     WFuncInfo() : paramCount(0)
     {
     }
@@ -27,14 +27,25 @@ public:
 
     bool isValid() const
     {
-        if (dllName.length() > 0 && funcName.length() > 0) {
-            return true;
-        }
-        return false;
+        return dllName.length() > 0 && funcName.length() > 0;
     }
 
     std::string dllName;
     std::string funcName;
+    size_t paramCount;
+};
+
+struct WSyscallInfo
+{
+    WSyscallInfo() : syscallId(0), paramCount(0)
+    {
+    }
+
+    bool load(const std::string& line, char delimiter);
+
+    bool update(const WSyscallInfo& syscall_info);
+
+    uint32_t syscallId;
     size_t paramCount;
 };
 
@@ -49,10 +60,14 @@ public:
     }
 
     size_t loadList(const char* filename);
-    bool appendFunc(WFuncInfo &info);
-
-    WFuncInfo* findFunc(const std::string& dllName, const std::string &funcName);
 
     std::vector<WFuncInfo> funcs;
+    std::map<uint32_t, WSyscallInfo> syscalls;
+
+private:
+    bool appendFunc(WFuncInfo& info);
+    void appendSyscall(WSyscallInfo& syscall_info);
+
+    WFuncInfo* findFunc(const std::string& dllName, const std::string& funcName);
 };
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A Pin Tool for tracing:
 + API calls, including [parameters of selected functions](https://github.com/hasherezade/tiny_tracer/wiki/Tracing-parameters-of-functions)
 + selected instructions: [RDTSC](https://c9x.me/x86/html/file_module_x86_id_278.html), [CPUID](https://c9x.me/x86/html/file_module_x86_id_45.html)
-+ inline system calls
++ inline system calls, including parameters of selected syscalls
 + transition between sections of the traced module (helpful in finding OEP of the packed module)
 
 Bypasses the anti-tracing check based on RDTSC.

--- a/TraceLog.cpp
+++ b/TraceLog.cpp
@@ -133,7 +133,7 @@ void TraceLog::logSyscall(const ADDRINT base, const ADDRINT rva, const ADDRINT p
     m_traceFile
         << std::hex << rva
         << DELIMITER
-        << "SYSCALL:"
+        << "SYSCALL:0x"
         << std::hex << param
         << std::endl;
     m_traceFile.flush();

--- a/Util.cpp
+++ b/Util.cpp
@@ -103,12 +103,12 @@ static inline void rtrim(std::string &s)
     rtrim(s);
 }
 
- int util::loadInt(const std::string &str)
+ int util::loadInt(const std::string &str, bool as_hex)
  {
      int intVal = 0;
      
      std::stringstream ss;
-     ss << std::dec << str;
+     ss << (as_hex ? std::hex : std::dec) << str;
      ss >> intVal;
 
      return intVal;

--- a/Util.h
+++ b/Util.h
@@ -28,5 +28,5 @@ namespace util {
     // trim from both ends (in place)
     void trim(std::string &s);
 
-    int loadInt(const std::string &str);
+    int loadInt(const std::string &str, bool as_hex = false);
 };


### PR DESCRIPTION
Hi,

Here's a second PR that completes the previous one. I re-used the existing "params" file to store the configuration for syscalls as well, mainly for the sake of simplicity. The changes are backward compatible so this shouldn't break anything for people that don't use the feature.
Tell me if you wish to separate the two configurations (for functions and for syscalls).

Example of a `params.txt` file:
```
kernel32;LoadLibraryW;1
kernel32;LoadLibraryA;1
kernel32;GetProcAddress;2
advapi32;RegQueryValueW;3
kernel32;CreateFileW;6
ntdll;ZwQuerySystemInformation;4
<SYSCALL>;0x36;4
<SYSCALL>;0x20;2
```

Example of a trace output:
```
1bd8;SYSCALL:0x36
	Arg[0] = 0
	Arg[1] = ptr 0x000000a18caff860 -> {\x00\x00\x00\x00\x00\x00\x00\x00}
	Arg[2] = 0x0000000000000040 = 64
	Arg[3] = ptr 0x000000a18caff8a0 -> {\x00\x00\x00\x00\x00\x00\x00\x00}
```