### PR TITLE
Avoid compilation errors with GCC 11.02 (Ubuntu 22.04)

### DIFF
--- a/Util.cpp
+++ b/Util.cpp
@@ -16,7 +16,7 @@ std::wstring util::hexdump(const uint8_t* in_buf, const size_t max_size)
             ss << char(in_buf[i]);
         }
         else {
-            ss << "\\x" << std::setfill('0') << std::setw(2) << std::hex << (unsigned int)in_buf[i];
+            ss << "\\x" << std::setfill(L'0') << std::setw(2) << std::hex << (unsigned int)in_buf[i];
         }
     }
     return ss.str();
@@ -58,7 +58,7 @@ std::string util::getDllName(const std::string& str)
     if (ext >= len) return "";
 
     std::string name = str.substr(found + 1, ext - (found + 1));
-    std::transform(name.begin(), name.end(), name.begin(), std::tolower);
+    std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c){ return std::tolower(c); });
     return name;
 }
 


### PR DESCRIPTION
I've made a couple of changes to avoid compilation errors on Ubuntu 22.04 (gcc 11.2).