### PR TITLE
Add a note on Intel PIN 3.26 on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ i.e.
 
 To compile the prepared project you need to use [Visual Studio >= 2012](https://visualstudio.microsoft.com/downloads/). It was tested with [Intel Pin 3.19 - 3.25](https://software.intel.com/en-us/articles/pin-a-binary-instrumentation-tool-downloads).<br/>
 Clone this repo into `\source\tools` that is inside your Pin root directory. Open the project in Visual Studio and build. Detailed description available [here](https://github.com/hasherezade/tiny_tracer/wiki/Installation#on-windows).<br/>
-When using Intel Pin >= 3.25, `pinipc.lib` needs to be added as an additional dependency in the project settings.
+When using Intel Pin >= 3.26, `pinipc.lib` needs to be added as an additional dependency in the project settings.
 
 ### On Linux
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ i.e.
 ### On Windows 
 
 To compile the prepared project you need to use [Visual Studio >= 2012](https://visualstudio.microsoft.com/downloads/). It was tested with [Intel Pin 3.19 - 3.25](https://software.intel.com/en-us/articles/pin-a-binary-instrumentation-tool-downloads).<br/>
-Clone this repo into `\source\tools` that is inside your Pin root directory. Open the project in Visual Studio and build. Detailed description available [here](https://github.com/hasherezade/tiny_tracer/wiki/Installation#on-windows).
+Clone this repo into `\source\tools` that is inside your Pin root directory. Open the project in Visual Studio and build. Detailed description available [here](https://github.com/hasherezade/tiny_tracer/wiki/Installation#on-windows).<br/>
+When using Intel Pin >= 3.25, `pinipc.lib` needs to be added as an additional dependency in the project settings.
 
 ### On Linux
 


### PR DESCRIPTION
`pinipc.lib` is required when compiling on Windows with Intel PIN >= 3.26, as mentioned in Intel's [release note](https://software.intel.com/sites/landingpage/pintool/docs/98690/README).