### PR TITLE
[FEATURE] Added INT1 in AntiDebug

### DIFF
--- a/AntiDebug.cpp
+++ b/AntiDebug.cpp
@@ -226,6 +226,10 @@ VOID AntiDbg::InterruptCheck(const CONTEXT* ctxt)
     int interruptID = 0;
     if (!fetchInterruptID(Address, interruptID)) return;
 
+    if (interruptID == 1) {
+        LogAntiDbg(wType, Address, "INT1",
+            "https://anti-debug.checkpoint.com/techniques/assembly.html#ice");
+    }
     if (interruptID == 3) {
         LogAntiDbg(wType, Address, "INT3",
             "https://anti-debug.checkpoint.com/techniques/assembly.html#int3");


### PR DESCRIPTION
Minor update to detect INT1 (as per https://anti-debug.checkpoint.com/techniques/assembly.html#ice).

In order to test it I created a couple of executable inlining the INT1 instruction and it seems to work fine.

I also tried to test it with Al-Kasher (which, accordingly to README should call INT1), but it was unsuccessful: by looking into the code, the call to `Interrupt 1` test uses the __debugbreak() intrinsic, which is actually translated in an INT3, so I think that the detection is working fine at the end.

Let me know what do you think about it or if a rework is required.
Thanks a lot!