### PR TITLE
[FEATURE} Added 3 new detections

### DIFF
--- a/AntiDebug.cpp
+++ b/AntiDebug.cpp
@@ -568,6 +568,8 @@ VOID AntiDbg::MonitorAntiDbgFunctions(IMG Image)
     funcToLink["GetWindowTextA"] = "https://anti-debug.checkpoint.com/techniques/interactive.html#suspendthread";
     funcToLink["GetWindowTextW"] = "https://anti-debug.checkpoint.com/techniques/interactive.html#suspendthread";
     funcToLink["SwitchDesktop"] = "https://anti-debug.checkpoint.com/techniques/interactive.html#switchdesktop";
+    funcToLink["OutputDebugStringA"] = "https://anti-debug.checkpoint.com/techniques/interactive.html#outputdebugstring";
+    funcToLink["OutputDebugStringW"] = "https://anti-debug.checkpoint.com/techniques/interactive.html#outputdebugstring";
 
     // API needed for Antidebug
     const std::string dllName = util::getDllName(IMG_Name(Image));
@@ -600,6 +602,14 @@ VOID AntiDbg::MonitorAntiDbgFunctions(IMG Image)
         AntiDbgAddCallbackBefore(Image, "RaiseException", 4, AntiDbg_RaiseException);
         AntiDbgAddCallbackBefore(Image, "DebugActiveProcess", 1, AntiDbgLogFuncOccurrence);
         AntiDbgAddCallbackBefore(Image, "GenerateConsoleCtrlEvent", 2, AntiDbgLogFuncOccurrence);
+
+        ////////////////////////////////////
+        // If AntiDebug level is Deep
+        ////////////////////////////////////
+        if (m_Settings.antidebug >= ANTIDEBUG_DEEP) {
+            AntiDbgAddCallbackBefore(Image, "OutputDebugStringA", 1, AntiDbgLogFuncOccurrence);
+            AntiDbgAddCallbackBefore(Image, "OutputDebugStringW", 1, AntiDbgLogFuncOccurrence);
+        }
     }
     if (util::iequals(dllName, "user32")) {
         AntiDbgAddCallbackBefore(Image, "BlockInput", 1, AntiDbg_BlockInput);

--- a/AntiDebug.cpp
+++ b/AntiDebug.cpp
@@ -567,6 +567,7 @@ VOID AntiDbg::MonitorAntiDbgFunctions(IMG Image)
     funcToLink["GenerateConsoleCtrlEvent"] = "https://anti-debug.checkpoint.com/techniques/interactive.html#generateconsolectrlevent";
     funcToLink["GetWindowTextA"] = "https://anti-debug.checkpoint.com/techniques/interactive.html#suspendthread";
     funcToLink["GetWindowTextW"] = "https://anti-debug.checkpoint.com/techniques/interactive.html#suspendthread";
+    funcToLink["SwitchDesktop"] = "https://anti-debug.checkpoint.com/techniques/interactive.html#switchdesktop";
 
     // API needed for Antidebug
     const std::string dllName = util::getDllName(IMG_Name(Image));
@@ -602,6 +603,7 @@ VOID AntiDbg::MonitorAntiDbgFunctions(IMG Image)
     }
     if (util::iequals(dllName, "user32")) {
         AntiDbgAddCallbackBefore(Image, "BlockInput", 1, AntiDbg_BlockInput);
+        AntiDbgAddCallbackBefore(Image, "SwitchDesktop", 1, AntiDbgLogFuncOccurrence);
 
         ////////////////////////////////////
         // If AntiDebug level is Deep

--- a/AntiDebug.cpp
+++ b/AntiDebug.cpp
@@ -565,6 +565,8 @@ VOID AntiDbg::MonitorAntiDbgFunctions(IMG Image)
     funcToLink["DbgUiDebugActiveProcess"] = "https://anti-debug.checkpoint.com/techniques/interactive.html#self-debugging";
     funcToLink["NtDebugActiveProcess"] = "https://anti-debug.checkpoint.com/techniques/interactive.html#self-debugging";
     funcToLink["GenerateConsoleCtrlEvent"] = "https://anti-debug.checkpoint.com/techniques/interactive.html#generateconsolectrlevent";
+    funcToLink["GetWindowTextA"] = "https://anti-debug.checkpoint.com/techniques/interactive.html#suspendthread";
+    funcToLink["GetWindowTextW"] = "https://anti-debug.checkpoint.com/techniques/interactive.html#suspendthread";
 
     // API needed for Antidebug
     const std::string dllName = util::getDllName(IMG_Name(Image));
@@ -600,6 +602,14 @@ VOID AntiDbg::MonitorAntiDbgFunctions(IMG Image)
     }
     if (util::iequals(dllName, "user32")) {
         AntiDbgAddCallbackBefore(Image, "BlockInput", 1, AntiDbg_BlockInput);
+
+        ////////////////////////////////////
+        // If AntiDebug level is Deep
+        ////////////////////////////////////
+        if (m_Settings.antidebug >= ANTIDEBUG_DEEP) {
+            AntiDbgAddCallbackBefore(Image, "GetWindowTextA", 3, AntiDbgLogFuncOccurrence);
+            AntiDbgAddCallbackBefore(Image, "GetWindowTextW", 3, AntiDbgLogFuncOccurrence);
+        }
     }
 
     // CloseHandle return value hook


### PR DESCRIPTION
I added 3 commits with some new Antidebug detections. Let me know what you think and/or if any rework is needed. Thanks!

### EnumWindows() and SuspendThread() 
-----

https://anti-debug.checkpoint.com/techniques/interactive.html#suspendthread

I placed this under DEEP level. Instead of hooking SuspendThread (as suggested in the CP article), I preferred to hook GetWindowTextA and GetWindowsTextW for the following reasons:
- SuspendThread is often used for other purposes
- the GetWindowText function are also used for other Antidebug checks, so even these will be covered here

Obviously there are legit uses of these functions, so that's why I placed it under DEEP level

### SwitchDesktop()
------

https://anti-debug.checkpoint.com/techniques/interactive.html#switchdesktop

Just checking for the function call. Nothing special to note here

### OutputDebugString 
---------

https://anti-debug.checkpoint.com/techniques/interactive.html#outputdebugstring

As the article says, this is an old technique, but used a lot in the past, so may be it's worth to be added.
Considering the possible legit usage, I put it under DEEP level.

