### PR TITLE
[FEATURE] Added new option: follow child processes

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -8,6 +8,7 @@
 #define DELIM '='
 
 #define KEY_FOLLOW_SHELLCODES           "FOLLOW_SHELLCODES"
+#define KEY_FOLLOW_CHILDPROCESSES       "FOLLOW_CHILDPROCESSES"
 #define KEY_LOG_RTDSC                   "TRACE_RDTSC"
 #define KEY_LOG_INT                     "TRACE_INT"
 #define KEY_LOG_SYSCALL                 "TRACE_SYSCALL"
@@ -131,6 +132,10 @@ bool fillSettings(Settings &s, const std::string &line)
         s.followShellcode = ConvertShcOption(val);
         isFilled = true;
     }
+    if (util::iequals(valName, KEY_FOLLOW_CHILDPROCESSES)) {
+        s.followChildprocesses = loadBoolean(valStr);
+        isFilled = true;
+    }
     if (util::iequals(valName, KEY_LOG_RTDSC)) {
         s.traceRDTSC = loadBoolean(valStr);
         isFilled = true;
@@ -250,6 +255,7 @@ bool Settings::saveINI(const std::string &filename)
         return false;
     }
     myfile << KEY_FOLLOW_SHELLCODES << DELIM << this->followShellcode << "\r\n";
+    myfile << KEY_FOLLOW_CHILDPROCESSES << DELIM << this->followChildprocesses << "\r\n";
     myfile << KEY_LOG_RTDSC << DELIM << booleanToStr(this->traceRDTSC) << "\r\n";
     myfile << KEY_LOG_INT << DELIM << booleanToStr(this->traceINT) << "\r\n";
     myfile << KEY_LOG_SYSCALL << DELIM << booleanToStr(this->traceSYSCALL) << "\r\n";

--- a/Settings.h
+++ b/Settings.h
@@ -103,6 +103,7 @@ public:
 
     Settings() 
         : followShellcode(SHELLC_FOLLOW_FIRST),
+        followChildprocesses(false),
         traceRDTSC(false),
         traceINT(false),
         traceSYSCALL(true),
@@ -128,6 +129,7 @@ public:
 
     t_shellc_options followShellcode;
 
+    bool followChildprocesses; // Follow Child Processes
     bool traceRDTSC; // Trace RDTSC
     bool traceINT; // trace INT
     bool traceSYSCALL; // Trace syscall instructions (i.e., syscall, int 2Eh, sysenter)

--- a/TinyTracer.cpp
+++ b/TinyTracer.cpp
@@ -1325,7 +1325,7 @@ BOOL FollowChild(CHILD_PROCESS childProcess, VOID * userData)
         INT childArgc;
         CHAR const* const* childArgv;
         CHILD_PROCESS_GetCommandLine(childProcess, &childArgc, &childArgv);
-        // Set Pin's command line for child process, rebuilding with the same options skipping "-m"
+        // Set Pin's command line for child process, rebuilding with the same options updated
         INT pinArgc = 0;
         const INT pinArgcMax = 40;
         CHAR const* pinArgv[pinArgcMax];
@@ -1346,6 +1346,8 @@ BOOL FollowChild(CHILD_PROCESS childProcess, VOID * userData)
         pinArgv[pinArgc++] = KnobStopOffsets.Value().c_str();
         pinArgv[pinArgc++] = "-l";
         pinArgv[pinArgc++] = KnobSyscallsTable.Value().c_str();
+        pinArgv[pinArgc++] = "-m";
+        pinArgv[pinArgc++] = childArgv[0];
         pinArgv[pinArgc++] = "--";
         // Now copy the child command line
         for (int i = 0; i < childArgc && pinArgc < pinArgcMax; i++) {

--- a/install32_64/TinyTracer.ini
+++ b/install32_64/TinyTracer.ini
@@ -6,6 +6,7 @@ FOLLOW_SHELLCODES=1
 ; 1 : follow only the first shellcode called from the main module
 ; 2 : follow also the shellcodes called recursively from the the original shellcode
 ; 3 : follow any shellcodes
+FOLLOW_CHILDPROCESSES=False
 TRACE_RDTSC=False
 TRACE_INT=False
 TRACE_SYSCALL=True

--- a/install32_64/run_me.bat
+++ b/install32_64/run_me.bat
@@ -97,8 +97,8 @@ if [%IS_ADMIN%] == [A] (
 
 set ADMIN_CMD=%PIN_TOOLS_DIR%\sudo.vbs
 
-set DLL_CMD=%PIN_DIR%\pin.exe -t %PINTOOL% -m "%TRACED_MODULE%" -o %TAG_FILE% -s %SETTINGS_FILE% -b "%WATCH_BEFORE%" -x "%EXCLUDED_FUNC%" -p "%STOP_OFFSETS%" -l "%SYSCALLS_TABLE%" -- "%DLL_LOAD%" "%TARGET_APP%" %DLL_EXPORTS%
-set EXE_CMD=%PIN_DIR%\pin.exe -t %PINTOOL% -m "%TRACED_MODULE%" -o %TAG_FILE% -s %SETTINGS_FILE% -b "%WATCH_BEFORE%" -x "%EXCLUDED_FUNC%" -p "%STOP_OFFSETS%" -l "%SYSCALLS_TABLE%" -- "%TARGET_APP%" %EXE_ARGS%
+set DLL_CMD=%PIN_DIR%\pin.exe -follow_execv -t %PINTOOL% -o %TAG_FILE% -s %SETTINGS_FILE% -b "%WATCH_BEFORE%" -x "%EXCLUDED_FUNC%" -p "%STOP_OFFSETS%" -l "%SYSCALLS_TABLE%" -- "%DLL_LOAD%" "%TARGET_APP%" %DLL_EXPORTS%
+set EXE_CMD=%PIN_DIR%\pin.exe -follow_execv -t %PINTOOL% -o %TAG_FILE% -s %SETTINGS_FILE% -b "%WATCH_BEFORE%" -x "%EXCLUDED_FUNC%" -p "%STOP_OFFSETS%" -l "%SYSCALLS_TABLE%" -- "%TARGET_APP%" %EXE_ARGS%
 
 ;rem "Trace EXE"
 if [%PE_TYPE%] == [exe] (

--- a/install32_64/run_me.bat
+++ b/install32_64/run_me.bat
@@ -97,8 +97,8 @@ if [%IS_ADMIN%] == [A] (
 
 set ADMIN_CMD=%PIN_TOOLS_DIR%\sudo.vbs
 
-set DLL_CMD=%PIN_DIR%\pin.exe -follow_execv -t %PINTOOL% -o %TAG_FILE% -s %SETTINGS_FILE% -b "%WATCH_BEFORE%" -x "%EXCLUDED_FUNC%" -p "%STOP_OFFSETS%" -l "%SYSCALLS_TABLE%" -- "%DLL_LOAD%" "%TARGET_APP%" %DLL_EXPORTS%
-set EXE_CMD=%PIN_DIR%\pin.exe -follow_execv -t %PINTOOL% -o %TAG_FILE% -s %SETTINGS_FILE% -b "%WATCH_BEFORE%" -x "%EXCLUDED_FUNC%" -p "%STOP_OFFSETS%" -l "%SYSCALLS_TABLE%" -- "%TARGET_APP%" %EXE_ARGS%
+set DLL_CMD=%PIN_DIR%\pin.exe -follow_execv -t %PINTOOL% -m "%TRACED_MODULE%" -o %TAG_FILE% -s %SETTINGS_FILE% -b "%WATCH_BEFORE%" -x "%EXCLUDED_FUNC%" -p "%STOP_OFFSETS%" -l "%SYSCALLS_TABLE%" -- "%DLL_LOAD%" "%TARGET_APP%" %DLL_EXPORTS%
+set EXE_CMD=%PIN_DIR%\pin.exe -follow_execv -t %PINTOOL% -m "%TRACED_MODULE%" -o %TAG_FILE% -s %SETTINGS_FILE% -b "%WATCH_BEFORE%" -x "%EXCLUDED_FUNC%" -p "%STOP_OFFSETS%" -l "%SYSCALLS_TABLE%" -- "%TARGET_APP%" %EXE_ARGS%
 
 ;rem "Trace EXE"
 if [%PE_TYPE%] == [exe] (


### PR DESCRIPTION
Hey!

First of all thanks a lot for your work on this project! 

As you can see in the commit, I didn't wrote too much code to implement this, it was more about reading the PIN docs actually :-).
I'd like to go through the mods:
- modifications to `Settings.cpp`, `Settings.h` and `TinyTracer.ini` are basically done to implement the switch to turn the feature on/off, so nothing fancy there
- `run_me.bat`: I added the proper `-follow-execv` option to the execution. This instruct PIN to re-execute the command line in case of a process creation. As you can see I removed the `-m` option used here. I had to do this because when a new process is spawned, PIN re-execute the original command line adding the new process at the end. If I leave the `-m`, this is going to impact the execution and it tries to execute again the parent process. If you prefer to keep this param here, it is possible to remove it in the callback (see later), but since I didn't found a reason to keep it, I thought to follow the "simple" way
- `TinyTracer.cpp`: since the `main` needs to be "idempotent" and it could be executed multiple times, I changed some things to allow the execution without collateral effects, like adding the PID to the tag file name (to avoid overwrites). Then I added a callback function called in case of subprocess creation (`FollowChild`): I kept it very simple for the time being, just checking if the follow child option is enabled and if so, go ahead with tracking. Here we can do also other things (like manipulating the command line as I said before), but it works perfectly even as it is.

It should work also for Linux, but I was not able to test it tbh.

Let me know what do you think and if any rework is needed.

Thanks again